### PR TITLE
InsertMenu button accepts custom function callback

### DIFF
--- a/src/Designer.js
+++ b/src/Designer.js
@@ -395,13 +395,17 @@ class Designer extends Component {
   }
 
   selectTool(tool) {
-    this.setState({
-      selectedTool: tool,
-      mode: modes.DRAW,
-      currentObjectIndex: null,
-      showHandler: false,
-      handler: null
-    });
+    if (typeof tool === 'function') {
+      tool(this);
+    } else {
+      this.setState({
+        selectedTool: tool,
+        mode: modes.DRAW,
+        currentObjectIndex: null,
+        showHandler: false,
+        handler: null
+      });
+    }
   }
 
   handleObjectChange(key, value) {


### PR DESCRIPTION
I want to add a delete button. And found it not possible.
So I make the selectTool accepts function.
Then I can use this code in my custom InsertMenu:

```js
const onDel = designer => {
  designer.removeCurrent();
};

...

<li
   ...
  onMouseDown={this.props.onSelect.bind(this, onDel)}
>
   ...
```