### PR TITLE
Issue when deleting multiple elements 

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,4 +256,4 @@ Here is a todo list that in my mind. You could extend this list.
 - Wassim Gharbi <wassgha@gmail.com> - [wassgha](https://github.com/wassgha/)
 - [iamraffe](https://github.com/iamraffe/)
 - [thatneat](https://github.com/thatneat/)
-- Dan Mahavithan - [mahathun](https://github.com/mahathun/)
+- Dan Mahavithana - [mahathun](https://github.com/mahathun/)

--- a/README.md
+++ b/README.md
@@ -256,3 +256,4 @@ Here is a todo list that in my mind. You could extend this list.
 - Wassim Gharbi <wassgha@gmail.com> - [wassgha](https://github.com/wassgha/)
 - [iamraffe](https://github.com/iamraffe/)
 - [thatneat](https://github.com/thatneat/)
+- Dan Mahavithan - [mahathun](https://github.com/mahathun/)

--- a/src/Designer.js
+++ b/src/Designer.js
@@ -301,7 +301,7 @@ class Designer extends Component {
     let mouse = this.getMouseCoords(event);
 
     let refs = this.objectRefs,
-        keys = Object.keys(refs),
+        keys = Object.keys(refs).filter((key)=>refs[key]),
         offset = this.getOffset();
 
     let currentRect = (refs[currentObjectIndex]


### PR DESCRIPTION
when deleting multiple elements quickly, refs will contain null elements as well, which will throw an error when trying run `refs[key].getBoundingClientRect()` as the refs[key] is null. Fixed it by making sure refs doesn't contain the key if the value is null.